### PR TITLE
Core plugin for root project

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,3 +2,9 @@ plugins {
     base
     kotlin("jvm") version "1.8.0"
 }
+
+subprojects {
+    apply {
+        plugin("kotlin")
+    }
+}

--- a/plugins/core/build.gradle.kts
+++ b/plugins/core/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins{
+    `java-gradle-plugin`
+    `maven-publish`
+}
+
+dependencies{
+
+}
+
+gradlePlugin{
+
+    isAutomatedPublishing = true
+
+    plugins {
+        create("core"){
+            id = "com.tmsolution.plugins.core"
+            implementationClass = "com.tmsolution.plugins.core.CorePlugin"
+        }
+    }
+}

--- a/plugins/core/build.gradle.kts
+++ b/plugins/core/build.gradle.kts
@@ -4,7 +4,7 @@ plugins{
 }
 
 dependencies{
-
+    implementation("io.spring.gradle:dependency-management-plugin:1.1.0")
 }
 
 gradlePlugin{

--- a/plugins/core/src/main/kotlin/com/tmsolution/plugins/core/CorePlugin.kt
+++ b/plugins/core/src/main/kotlin/com/tmsolution/plugins/core/CorePlugin.kt
@@ -1,0 +1,14 @@
+package com.tmsolution.plugins.core
+
+import com.tmsolution.plugins.core.abstract.AbstractPlugin
+import com.tmsolution.plugins.core.dsl.applyDefaults
+import org.gradle.api.Project
+
+class CorePlugin : AbstractPlugin() {
+
+    override val configure: Project.() -> Unit = {
+        subprojects {
+            it.applyDefaults()
+        }
+    }
+}

--- a/plugins/core/src/main/kotlin/com/tmsolution/plugins/core/abstract/AbstractPlugin.kt
+++ b/plugins/core/src/main/kotlin/com/tmsolution/plugins/core/abstract/AbstractPlugin.kt
@@ -1,0 +1,18 @@
+package com.tmsolution.plugins.core.abstract
+
+import com.tmsolution.plugins.core.dsl.applyDefaults
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+abstract class AbstractPlugin : Plugin<Project> {
+
+    protected open val includedPlugins:List<String> = listOf()
+
+    protected abstract val configure: Project.() -> Unit
+
+    override fun apply(target: Project) = target.run {
+        applyDefaults()
+        includedPlugins.forEach(pluginManager::apply)
+        configure(this)
+    }
+}

--- a/plugins/core/src/main/kotlin/com/tmsolution/plugins/core/constants/Plugins.kt
+++ b/plugins/core/src/main/kotlin/com/tmsolution/plugins/core/constants/Plugins.kt
@@ -1,0 +1,8 @@
+package com.tmsolution.plugins.core.constants
+
+object Plugins {
+
+    const val BASE = "base"
+    const val IDEA = "idea"
+    const val SPRING_DEPENDENCY_MANAGEMENT = "io.spring.dependency-management"
+}

--- a/plugins/core/src/main/kotlin/com/tmsolution/plugins/core/dsl/ProjectExt.kt
+++ b/plugins/core/src/main/kotlin/com/tmsolution/plugins/core/dsl/ProjectExt.kt
@@ -1,0 +1,26 @@
+package com.tmsolution.plugins.core.dsl
+
+import com.tmsolution.plugins.core.constants.Plugins
+import org.gradle.api.Project
+import org.gradle.api.tasks.testing.Test
+
+fun Project.applyDefaults(): Project{
+
+    listOf(
+        Plugins.BASE,
+        Plugins.SPRING_DEPENDENCY_MANAGEMENT,
+        Plugins.IDEA
+    ).forEach(pluginManager::apply)
+
+    repositories.apply {
+        mavenCentral()
+    }
+
+    afterEvaluate {
+        tasks.withType(Test::class.java){
+            it.useJUnitPlatform()
+        }
+    }
+
+    return this;
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,3 +13,5 @@ dependencyResolutionManagement {
 }
 
 rootProject.name = "gradle-plugins"
+
+include(":plugins:core")


### PR DESCRIPTION
Core plugin is part of assortment of custom plugins, providing base plugins like `spring-boot-management` and gradle project settings to be applied to all projects.

- Provides plugins: `base` `idea` `spring-dependency-management`
- Project extension dsl configured to above plugins, mavenCentral and jUnitPlatform.